### PR TITLE
feat: set backstage cloud-provider

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Terraform Format Check
         run: make fmt-check
 
-      - name: Stub Github App credentials (required for validation)
+      - name: Stub GitHub App credentials (required for validation)
         run: cd ./examples/with-backstage && STUB_FILE=1 node create-gh-app/index.js
 
       - name: Terraform Validate

--- a/examples/with-backstage/README.md
+++ b/examples/with-backstage/README.md
@@ -108,6 +108,7 @@ Once you are finished with the reference architecture, you can remove all provis
 | [github_actions_organization_secret.backstage_humanitec_token](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_organization_secret) | resource |
 | [github_actions_organization_variable.backstage_aws_region](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_organization_variable) | resource |
 | [github_actions_organization_variable.backstage_aws_role_arn](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_organization_variable) | resource |
+| [github_actions_organization_variable.backstage_cloud_provider](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_organization_variable) | resource |
 | [github_actions_organization_variable.backstage_humanitec_org_id](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_organization_variable) | resource |
 | [github_repository.backstage](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
 | [humanitec_application.backstage](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/application) | resource |
@@ -118,6 +119,7 @@ Once you are finished with the reference architecture, you can remove all provis
 | [humanitec_resource_definition_criteria.backstage_postgres](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.backstage_workload](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_value.aws_default_region](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
+| [humanitec_value.backstage_cloud_provider](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
 | [humanitec_value.backstage_github_app_client_id](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
 | [humanitec_value.backstage_github_app_client_secret](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
 | [humanitec_value.backstage_github_app_id](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |

--- a/examples/with-backstage/aws-github.tf
+++ b/examples/with-backstage/aws-github.tf
@@ -1,5 +1,6 @@
 locals {
-  name = "gha-ecr-push"
+  name           = "gha-ecr-push"
+  cloud_provider = "aws"
 }
 
 # Create a role for GitHub Actions to push to ECR using OpenID Connect (OIDC) so we don't need to store AWS credentials in GitHub

--- a/examples/with-backstage/backstage-github.tf
+++ b/examples/with-backstage/backstage-github.tf
@@ -14,6 +14,12 @@ locals {
   backstage_repo = "backstage"
 }
 
+resource "github_actions_organization_variable" "backstage_cloud_provider" {
+  variable_name = "CLOUD_PROVIDER"
+  visibility    = "all"
+  value         = local.cloud_provider
+}
+
 resource "github_actions_organization_variable" "backstage_aws_region" {
   variable_name = "AWS_REGION"
   visibility    = "all"

--- a/examples/with-backstage/backstage-humanitec.tf
+++ b/examples/with-backstage/backstage-humanitec.tf
@@ -69,6 +69,14 @@ resource "humanitec_value" "backstage_humanitec_token" {
   is_secret   = true
 }
 
+resource "humanitec_value" "backstage_cloud_provider" {
+  app_id      = humanitec_application.backstage.id
+  key         = "CLOUD_PROVIDER"
+  description = ""
+  value       = local.cloud_provider
+  is_secret   = false
+}
+
 resource "humanitec_value" "aws_default_region" {
   app_id      = humanitec_application.backstage.id
   key         = "AWS_DEFAULT_REGION"


### PR DESCRIPTION
Set the `CLOUD_PROVIDER` variable in github and backstage, which is required to support other cloud providers.