### PR TITLE
feat: set loadbalancer_hosted_zone

### DIFF
--- a/modules/base/README.md
+++ b/modules/base/README.md
@@ -43,6 +43,7 @@ Module that provides the reference architecture.
 | [humanitec_resource_definition_criteria.k8s_logging](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.k8s_namespace](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_elb_hosted_zone_id.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/elb_hosted_zone_id) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [kubernetes_service.ingress_nginx_controller](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/service) | data source |
 

--- a/modules/base/humanitec.tf
+++ b/modules/base/humanitec.tf
@@ -4,6 +4,8 @@ locals {
   ingress_address = data.kubernetes_service.ingress_nginx_controller.status.0.load_balancer.0.ingress.0.hostname
 }
 
+data "aws_elb_hosted_zone_id" "main" {}
+
 resource "humanitec_resource_definition" "k8s_cluster_driver" {
   driver_type = "humanitec/k8s-cluster-eks"
   id          = var.cluster_name
@@ -12,9 +14,10 @@ resource "humanitec_resource_definition" "k8s_cluster_driver" {
 
   driver_inputs = {
     values_string = jsonencode({
-      "name"         = module.aws_eks.cluster_name
-      "loadbalancer" = local.ingress_address
-      "region"       = var.region
+      "name"                     = module.aws_eks.cluster_name
+      "loadbalancer"             = local.ingress_address
+      "loadbalancer_hosted_zone" = data.aws_elb_hosted_zone_id.main.id
+      "region"                   = var.region
     }),
     secrets_string = jsonencode({
       "credentials" = {


### PR DESCRIPTION
Setting the `loadbalancer_hosted_zone` will tell Humanitec to use an alias record instead, which [is generally preferable](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-choosing-alias-non-alias.html). 