### PR TITLE
Update provider.tf - bump humanitec min version to 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Once you are finished with the reference architecture, you can remove all provis
 |------|---------|
 | terraform | >= 1.3.0 |
 | aws | ~> 5.17 |
-| humanitec | ~> 0.13 |
+| humanitec | ~> 1.0 |
 
 ### Modules
 

--- a/examples/with-backstage/README.md
+++ b/examples/with-backstage/README.md
@@ -75,7 +75,7 @@ Once you are finished with the reference architecture, you can remove all provis
 | terraform | >= 1.3.0 |
 | aws | ~> 5.17 |
 | github | ~> 5.38 |
-| humanitec | ~> 0.13 |
+| humanitec | ~> 1.0 |
 
 ### Providers
 
@@ -83,7 +83,7 @@ Once you are finished with the reference architecture, you can remove all provis
 |------|---------|
 | aws | ~> 5.17 |
 | github | ~> 5.38 |
-| humanitec | ~> 0.13 |
+| humanitec | ~> 1.0 |
 
 ### Modules
 

--- a/examples/with-backstage/provider.tf
+++ b/examples/with-backstage/provider.tf
@@ -6,7 +6,7 @@ terraform {
     }
     humanitec = {
       source  = "humanitec/humanitec"
-      version = "~> 0.13"
+      version = "~> 1.0"
     }
     github = {
       source  = "integrations/github"

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     humanitec = {
       source  = "humanitec/humanitec"
-      version = "~> 0.13"
+      version = "~> 1.0"
     }
   }
   required_version = ">= 1.3.0"


### PR DESCRIPTION
Otherwise `make validate` will fail with:
```
│ Error: Failed to query available provider packages
│ 
│ Could not retrieve the list of available versions for provider
│ humanitec/humanitec: no available releases match the given constraints ~>
│ 0.13, ~> 1.0
╵

Error: Terraform exited with code 1.
make: *** [Makefile:24: validate-./examples/with-backstage] Error 1
```