### PR TITLE
feat: resource account

### DIFF
--- a/examples/with-backstage/backstage-humanitec.tf
+++ b/examples/with-backstage/backstage-humanitec.tf
@@ -126,8 +126,7 @@ resource "humanitec_resource_definition_criteria" "backstage_k8s_service_account
 module "backstage_iam_policy_ecr_create_repository" {
   source = "git::https://github.com/humanitec-architecture/resource-packs-aws.git//humanitec-resource-defs/iam-policy/ecr-create-repository"
 
-  access_key             = module.base.aws_access_key_id
-  secret_key             = module.base.aws_secret_access_key
+  driver_account         = module.base.humanitec_resource_account_id
   resource_packs_aws_rev = var.resource_packs_aws_rev
   region                 = var.aws_region
 
@@ -146,8 +145,7 @@ resource "humanitec_resource_definition_criteria" "backstage_iam_policy_ecr_crea
 module "backstage_iam_role_service_account" {
   source = "git::https://github.com/humanitec-architecture/resource-packs-aws.git//humanitec-resource-defs/iam-role/service-account"
 
-  access_key             = module.base.aws_access_key_id
-  secret_key             = module.base.aws_secret_access_key
+  driver_account         = module.base.humanitec_resource_account_id
   resource_packs_aws_rev = var.resource_packs_aws_rev
   region                 = var.aws_region
 

--- a/modules/base/README.md
+++ b/modules/base/README.md
@@ -19,6 +19,7 @@ Module that provides the reference architecture.
 | <a name="provider_helm"></a> [helm](#provider\_helm) | n/a |
 | <a name="provider_humanitec"></a> [humanitec](#provider\_humanitec) | n/a |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.0.3 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
@@ -32,16 +33,18 @@ Module that provides the reference architecture.
 
 | Name | Type |
 |------|------|
-| [aws_iam_access_key.humanitec_svc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
-| [aws_iam_user.humanitec_svc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
-| [aws_iam_user_policy_attachment.humanitec_svc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
+| [aws_iam_role.humanitec_svc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.humanitec_svc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [helm_release.ingress_nginx](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [humanitec_resource_account.cluster_account](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_account) | resource |
 | [humanitec_resource_definition.k8s_cluster_driver](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition) | resource |
 | [humanitec_resource_definition.k8s_namespace](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition) | resource |
 | [humanitec_resource_definition_criteria.k8s_cluster_driver](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.k8s_namespace](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
+| [random_password.external_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_elb_hosted_zone_id.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/elb_hosted_zone_id) | data source |
+| [aws_iam_policy_document.instance_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [kubernetes_service.ingress_nginx_controller](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/service) | data source |
 
@@ -49,14 +52,14 @@ Module that provides the reference architecture.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_additional_aws_auth_users"></a> [additional\_aws\_auth\_users](#input\_additional\_aws\_auth\_users) | Additional users add to the k8s aws-auth configmap | `list(any)` | `[]` | no |
+| <a name="input_additional_k8s_access_entries"></a> [additional\_k8s\_access\_entries](#input\_additional\_k8s\_access\_entries) | Additional access entries add to the k8s aws-auth configmap | <pre>list(object({<br>    id            = string<br>    principal_arn = string<br>    groups        = list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_capacity_type"></a> [capacity\_type](#input\_capacity\_type) | Defines whether to use ON\_DEMAND or SPOT EC2 instances for EKS nodes | `string` | `"ON_DEMAND"` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name for the EKS cluster | `string` | `"ref-arch"` | no |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Version of the EKS cluster to deploy | `string` | `null` | no |
 | <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Disk size in GB to use for EKS nodes | `number` | `20` | no |
 | <a name="input_eks_public_access_cidrs"></a> [eks\_public\_access\_cidrs](#input\_eks\_public\_access\_cidrs) | List of CIDRs that can access the EKS cluster's public endpoint | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Name of the environment to be deployed into | `string` | `"development"` | no |
-| <a name="input_iam_user_name"></a> [iam\_user\_name](#input\_iam\_user\_name) | Name of the IAM user to create for Humanitec EKS access | `string` | `"svc-humanitec"` | no |
+| <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Name of the IAM user to create for Humanitec EKS access | `string` | `"svc-humanitec"` | no |
 | <a name="input_ingress_nginx_min_unavailable"></a> [ingress\_nginx\_min\_unavailable](#input\_ingress\_nginx\_min\_unavailable) | Number of allowed unavaiable replicas for the ingress-nginx controller | `number` | `1` | no |
 | <a name="input_ingress_nginx_replica_count"></a> [ingress\_nginx\_replica\_count](#input\_ingress\_nginx\_replica\_count) | Number of replicas for the ingress-nginx controller | `number` | `2` | no |
 | <a name="input_instance_types"></a> [instance\_types](#input\_instance\_types) | List of EC2 instances types to use for EKS nodes | `list(string)` | <pre>[<br>  "t3.large"<br>]</pre> | no |
@@ -70,14 +73,13 @@ Module that provides the reference architecture.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_aws_access_key_id"></a> [aws\_access\_key\_id](#output\_aws\_access\_key\_id) | n/a |
-| <a name="output_aws_secret_access_key"></a> [aws\_secret\_access\_key](#output\_aws\_secret\_access\_key) | n/a |
 | <a name="output_eks_cluster_certificate_authority_data"></a> [eks\_cluster\_certificate\_authority\_data](#output\_eks\_cluster\_certificate\_authority\_data) | Base64 encoded certificate data required to communicate with the cluster |
 | <a name="output_eks_cluster_endpoint"></a> [eks\_cluster\_endpoint](#output\_eks\_cluster\_endpoint) | Endpoint for your Kubernetes API server |
 | <a name="output_eks_cluster_name"></a> [eks\_cluster\_name](#output\_eks\_cluster\_name) | The name of the EKS cluster |
 | <a name="output_eks_oidc_provider"></a> [eks\_oidc\_provider](#output\_eks\_oidc\_provider) | The OpenID Connect identity provider (issuer URL without leading `https://`) |
 | <a name="output_eks_oidc_provider_arn"></a> [eks\_oidc\_provider\_arn](#output\_eks\_oidc\_provider\_arn) | The ARN of the OIDC Provider |
 | <a name="output_environment"></a> [environment](#output\_environment) | Name of the environment to be deployed into |
+| <a name="output_humanitec_resource_account_id"></a> [humanitec\_resource\_account\_id](#output\_humanitec\_resource\_account\_id) | Humanitec resource account id for the cluster |
 | <a name="output_ingress_nginx_external_dns"></a> [ingress\_nginx\_external\_dns](#output\_ingress\_nginx\_external\_dns) | External DNS entry for the Nginx ingress controller |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | VPC id |
 <!-- END_TF_DOCS -->

--- a/modules/base/outputs.tf
+++ b/modules/base/outputs.tf
@@ -47,12 +47,9 @@ output "ingress_nginx_external_dns" {
 }
 
 
-# Key
+# Humanitec
 
-output "aws_access_key_id" {
-  value = aws_iam_access_key.humanitec_svc.id
-}
-
-output "aws_secret_access_key" {
-  value = aws_iam_access_key.humanitec_svc.secret
+output "humanitec_resource_account_id" {
+  description = "Humanitec resource account id for the cluster"
+  value       = humanitec_resource_account.cluster_account.id
 }

--- a/modules/base/variables.tf
+++ b/modules/base/variables.tf
@@ -66,16 +66,20 @@ variable "capacity_type" {
   default     = "ON_DEMAND"
 }
 
-variable "iam_user_name" {
+variable "iam_role_name" {
   description = "Name of the IAM user to create for Humanitec EKS access"
   type        = string
   default     = "svc-humanitec"
 }
 
-variable "additional_aws_auth_users" {
-  description = "Additional users add to the k8s aws-auth configmap"
-  type        = list(any)
-  default     = []
+variable "additional_k8s_access_entries" {
+  description = "Additional access entries add to the k8s aws-auth configmap"
+  type = list(object({
+    id            = string
+    principal_arn = string
+    groups        = list(string)
+  }))
+  default = []
 }
 
 variable "ingress_nginx_replica_count" {


### PR DESCRIPTION
Use a resource account instead of injecting the credentials directly into the driver.

Switch to a role and temporary credentials to follow security best practices.