### PR TITLE
Changed rights on policy to enable repo creation from GHA instead of scaffolder

### DIFF
--- a/examples/with-backstage/aws-github.tf
+++ b/examples/with-backstage/aws-github.tf
@@ -42,7 +42,9 @@ resource "aws_iam_policy" "ecr_push_policy" {
           "ecr:UploadLayerPart",
           "ecr:InitiateLayerUpload",
           "ecr:BatchCheckLayerAvailability",
-          "ecr:PutImage"
+          "ecr:PutImage",
+          "ecr:DescribeRepositories",
+          "ecr:CreateRepository"
         ]
         Effect   = "Allow"
         Resource = "*"


### PR DESCRIPTION
Needed to enable https://github.com/humanitec-architecture/backstage/pull/22

Signed-off-by: jayonthenet <clemens@humanitec.com>