### PR TITLE
feat: set backstage service-to-service auth key

### DIFF
--- a/examples/with-backstage/README.md
+++ b/examples/with-backstage/README.md
@@ -76,6 +76,7 @@ Once you are finished with the reference architecture, you can remove all provis
 | aws | ~> 5.17 |
 | github | ~> 5.38 |
 | humanitec | ~> 1.0 |
+| random | ~> 3.5 |
 
 ### Providers
 
@@ -84,6 +85,7 @@ Once you are finished with the reference architecture, you can remove all provis
 | aws | ~> 5.17 |
 | github | ~> 5.38 |
 | humanitec | ~> 1.0 |
+| random | ~> 3.5 |
 
 ### Modules
 
@@ -118,6 +120,7 @@ Once you are finished with the reference architecture, you can remove all provis
 | [humanitec_resource_definition_criteria.backstage_mysql](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.backstage_postgres](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
 | [humanitec_resource_definition_criteria.backstage_workload](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/resource_definition_criteria) | resource |
+| [humanitec_value.app_config_backend_auth_keys](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
 | [humanitec_value.aws_default_region](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
 | [humanitec_value.backstage_cloud_provider](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
 | [humanitec_value.backstage_github_app_client_id](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
@@ -128,6 +131,7 @@ Once you are finished with the reference architecture, you can remove all provis
 | [humanitec_value.backstage_github_org_id](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
 | [humanitec_value.backstage_humanitec_org](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
 | [humanitec_value.backstage_humanitec_token](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/value) | resource |
+| [random_bytes.backstage_service_to_service_auth_key](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/bytes) | resource |
 
 ### Inputs
 

--- a/examples/with-backstage/backstage-humanitec.tf
+++ b/examples/with-backstage/backstage-humanitec.tf
@@ -85,6 +85,20 @@ resource "humanitec_value" "aws_default_region" {
   is_secret   = false
 }
 
+resource "random_bytes" "backstage_service_to_service_auth_key" {
+  length = 24
+}
+
+resource "humanitec_value" "app_config_backend_auth_keys" {
+  app_id      = humanitec_application.backstage.id
+  key         = "APP_CONFIG_backend_auth_keys"
+  description = "Backstage service-to-service-auth keys"
+  value = jsonencode([{
+    secret = random_bytes.backstage_service_to_service_auth_key.base64
+  }])
+  is_secret = true
+}
+
 # Configure required resources for backstage
 
 locals {

--- a/examples/with-backstage/provider.tf
+++ b/examples/with-backstage/provider.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "integrations/github"
       version = "~> 5.38"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
   }
   required_version = ">= 1.3.0"
 }


### PR DESCRIPTION
Setting this key is require while we still have legacy plugins https://backstage.io/docs/auth/service-to-service-auth/#legacy-tokens

Required for https://github.com/humanitec-architecture/backstage/pull/21