### PR TITLE
Fix: Adjust module source to support terraform 1.10.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Once you are finished with the reference architecture, you can remove all provis
 |------|--------|---------|
 | base | ./modules/base | n/a |
 | github | ./modules/github | n/a |
-| github\_app | github.com/humanitec-architecture/shared-terraform-modules | v2024-06-12//modules/github-app |
+| github\_app | github.com/humanitec-architecture/shared-terraform-modules//modules/github-app | v2024-06-12 |
 | portal\_backstage | ./modules/portal-backstage | n/a |
 
 ### Resources

--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ locals {
 module "github_app" {
   count = var.with_backstage ? 1 : 0
 
-  source = "github.com/humanitec-architecture/shared-terraform-modules?ref=v2024-06-12//modules/github-app"
+  source = "github.com/humanitec-architecture/shared-terraform-modules//modules/github-app?ref=v2024-06-12"
 
   credentials_file = "${path.module}/${local.github_app_credentials_file}"
 }

--- a/modules/base/README.md
+++ b/modules/base/README.md
@@ -32,8 +32,8 @@ Module that provides the reference architecture.
 |------|--------|---------|
 | aws\_eks | terraform-aws-modules/eks/aws | ~> 20.2 |
 | aws\_vpc | terraform-aws-modules/vpc/aws | ~> 5.1 |
-| default\_mysql | github.com/humanitec-architecture/resource-packs-in-cluster | v2024-06-05//humanitec-resource-defs/mysql/basic |
-| default\_postgres | github.com/humanitec-architecture/resource-packs-in-cluster | v2024-06-05//humanitec-resource-defs/postgres/basic |
+| default\_mysql | github.com/humanitec-architecture/resource-packs-in-cluster//humanitec-resource-defs/mysql/basic | v2024-06-05 |
+| default\_postgres | github.com/humanitec-architecture/resource-packs-in-cluster//humanitec-resource-defs/postgres/basic | v2024-06-05 |
 | ebs\_csi\_irsa\_role | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.30 |
 
 ### Resources

--- a/modules/base/humanitec.tf
+++ b/modules/base/humanitec.tf
@@ -72,7 +72,7 @@ resource "humanitec_resource_definition_criteria" "k8s_namespace" {
 # in-cluster postgres
 
 module "default_postgres" {
-  source = "github.com/humanitec-architecture/resource-packs-in-cluster?ref=v2024-06-05//humanitec-resource-defs/postgres/basic"
+  source = "github.com/humanitec-architecture/resource-packs-in-cluster//humanitec-resource-defs/postgres/basic?ref=v2024-06-05"
 
   prefix = local.res_def_prefix
 }
@@ -83,7 +83,7 @@ resource "humanitec_resource_definition_criteria" "default_postgres" {
 }
 
 module "default_mysql" {
-  source = "github.com/humanitec-architecture/resource-packs-in-cluster?ref=v2024-06-05//humanitec-resource-defs/mysql/basic"
+  source = "github.com/humanitec-architecture/resource-packs-in-cluster//humanitec-resource-defs/mysql/basic?ref=v2024-06-05"
 
   prefix = local.res_def_prefix
 }

--- a/modules/portal-backstage/README.md
+++ b/modules/portal-backstage/README.md
@@ -22,8 +22,8 @@ This module deploys the [Humanitec Reference Architecture Backstage](https://git
 
 | Name | Source | Version |
 |------|--------|---------|
-| backstage\_postgres | github.com/humanitec-architecture/resource-packs-in-cluster | v2024-06-05//humanitec-resource-defs/postgres/basic |
-| portal\_backstage | github.com/humanitec-architecture/shared-terraform-modules | v2024-06-12//modules/portal-backstage |
+| backstage\_postgres | github.com/humanitec-architecture/resource-packs-in-cluster//humanitec-resource-defs/postgres/basic | v2024-06-05 |
+| portal\_backstage | github.com/humanitec-architecture/shared-terraform-modules//modules/portal-backstage | v2024-06-12 |
 
 ### Resources
 

--- a/modules/portal-backstage/main.tf
+++ b/modules/portal-backstage/main.tf
@@ -20,7 +20,7 @@ locals {
 }
 
 module "portal_backstage" {
-  source = "github.com/humanitec-architecture/shared-terraform-modules?ref=v2024-06-12//modules/portal-backstage"
+  source = "github.com/humanitec-architecture/shared-terraform-modules//modules/portal-backstage?ref=v2024-06-12"
 
   cloud_provider = "aws"
 
@@ -45,7 +45,7 @@ locals {
 # in-cluster postgres
 
 module "backstage_postgres" {
-  source = "github.com/humanitec-architecture/resource-packs-in-cluster?ref=v2024-06-05//humanitec-resource-defs/postgres/basic"
+  source = "github.com/humanitec-architecture/resource-packs-in-cluster//humanitec-resource-defs/postgres/basic?ref=v2024-06-05"
 
   prefix = local.res_def_prefix
 }


### PR DESCRIPTION
This PR adjusts the `source` format in `modules` referencing other GitHub repositories. The current format breaks `terraform init` for `terraform` clients of the current version `1.10.x`.

The new format is compatible across older and newer versions (tested `1.5.7`, `1.9.2`, and `1.10.4`) as well as the current OpenTofu version `1.9.0`.